### PR TITLE
Clarify codex web_search feature rename

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -25,5 +25,6 @@ shell_snapshot = true
 skills = true
 streamable_shell = true
 unified_exec = true
-web_search_request = true
+# renamed from web_search_request
+web_search = true
 steer = true


### PR DESCRIPTION
### Motivation
- Replace the deprecated `web_search_request` feature flag with the current `web_search` key and document the rename to avoid confusion and warnings.

### Description
- Updated `config/codex/config.toml` to remove `web_search_request`, add `web_search = true`, and include an inline comment `# renamed from web_search_request` in the `[features]` section.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aa2655b0832fb5b99072f17df8c2)