### PR TITLE
Move `web_search` to top-level and remove lookup note

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,5 +1,6 @@
 model = "gpt-5.2-codex"
 model_reasoning_effort = "high"
+web_search = "live"
 # full-auto mode
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
@@ -25,5 +26,4 @@ shell_snapshot = true
 skills = true
 streamable_shell = true
 unified_exec = true
-web_search = true
 steer = true


### PR DESCRIPTION
### Motivation
- Surface the `web_search` setting at the top level to resolve the deprecated `[features].web_search` usage and set it to `"live"` as the intended runtime mode.
- Remove the previously added documentation note file after feedback that the extra `notes/web_search_lookup.md` was not desired.

### Description
- Add `web_search = "live"` at the top level of `config/codex/config.toml` to replace the deprecated boolean feature flag.
- Remove `web_search = true` from the `[features]` section in `config/codex/config.toml` to avoid the deprecated configuration.
- Delete the `notes/web_search_lookup.md` file (`notes/web_search_lookup.md`) which documented failed lookup attempts and was removed per feedback.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833c7b02d8832f9560fe11f9101012)