### PR TITLE
Enable collaboration modes in Codex config

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -22,6 +22,7 @@ env_key = "AICODING_API_KEY"
 wire_api = "responses"
 
 [features]
+collaboration_modes = true
 shell_snapshot = true
 skills = true
 streamable_shell = true


### PR DESCRIPTION
### Motivation

- Enable collaboration-related behavior in Codex by turning on the collaboration feature flag so multi-agent or collaborative workflows can be used.

### Description

- Add `collaboration_modes = true` to the `[features]` section of `config/codex/config.toml`.

### Testing

- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857a778cf8832f8561dabbff90c2c5)